### PR TITLE
Update to work with jsonapi:8.x-2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This is a good opportunity to point out that there are no dependencies between w
 
 > If you are running Islandora in a CLAW Playbook Vagrant guest virtual machine and Riprap on the Vagrant host machine, start the Riprap web server by running `php bin/console server:start *:8001` in the Riprap directory. See the [Islandora Riprap](https://github.com/mjordan/islandora_riprap) README file for more information. Otherwise, the Symfony web server will have a port conflict with the Apache web server mapped to port `8000` on the host machine.
 
-The "islandora" configuration works like the other two sample configurations, but it queries Drupal's [JSON:API](https://www.drupal.org/project/jsonapi) (not included in the default CLAW installation) for the list of resources to audit (using the descriptively named `PluginFetchResourceListFromDrupal` plugin), and it queries the REST API of the Fedora repository that accompanies Drupal in the Islandora stack for the digests of those files (using the `PluginFetchDigestFromFedoraAPI` plugin). Both of those plugins require more configuration options the the other plugins we have seen so far. Any static data a plugin needs can be included in a configuration file.
+The "islandora" configuration works like the other two sample configurations, but it queries Drupal's [JSON:API](https://www.drupal.org/project/jsonapi) for the list of resources to audit (using the descriptively named `PluginFetchResourceListFromDrupal` plugin), and it queries the REST API of the Fedora repository that accompanies Drupal in the Islandora stack for the digests of those files (using the `PluginFetchDigestFromFedoraAPI` plugin). Both of those plugins require more configuration options the the other plugins we have seen so far. Any static data a plugin needs can be included in a configuration file. Note, the JSON:API module is not included in the default CLAW installation, currently using Drupal 8.6, and must be installed separately. However the JSON:API module will be included in Drupal 8.7 as a core module.
 
 Within the Drupal user interface, the [Islandora Riprap](https://github.com/mjordan/islandora_riprap) module provides reports on whether Riprap has recorded any failed fixity check events (i.e., digest mismatches for the same resource) over time. The module gets this information via the Riprap REST API, described in the next section.
 
@@ -145,7 +145,7 @@ You should get a response like this:
 > User-Agent: curl/7.58.0
 > Accept: */*
 > Resource-ID: resources/filesystemexample/resourcefiles/file3.bin
-> 
+>
 < HTTP/1.1 200 OK
 < Host: localhost:8001
 < Date: Mon, 21 Jan 2019 07:07:18 -0800
@@ -154,7 +154,7 @@ You should get a response like this:
 < Cache-Control: no-cache, private
 < Date: Mon, 21 Jan 2019 15:07:18 GMT
 < Content-Type: application/json
-< 
+<
 * Closing connection 0
 
 ```

--- a/src/Plugin/PluginFetchResourceListFromDrupal.php
+++ b/src/Plugin/PluginFetchResourceListFromDrupal.php
@@ -100,7 +100,7 @@ class PluginFetchResourceListFromDrupal extends AbstractFetchResourceListPlugin
 
         $output_resource_records = array();
         foreach ($node_list_array['data'] as $node) {
-            $nid = $node['attributes']['nid'];
+            $nid = $node['attributes']['drupal_internal__nid'];
             // Get the media associated with this node using the Islandora-supplied Manage Media View.
             $media_client = new \GuzzleHttp\Client();
             $media_url = $this->drupal_base_url . '/node/' . $nid . '/media';

--- a/src/Plugin/PluginFetchResourceListFromDrupal.php
+++ b/src/Plugin/PluginFetchResourceListFromDrupal.php
@@ -181,7 +181,7 @@ class PluginFetchResourceListFromDrupal extends AbstractFetchResourceListPlugin
         if ($this->logger) {
             $this->logger->info("PluginFetchResourceListFromDrupal executed");
         }
- 
+
         return $output_resource_records;
     }
 
@@ -249,8 +249,9 @@ class PluginFetchResourceListFromDrupal extends AbstractFetchResourceListPlugin
         // We are not on the last page, so increment the page offset counter.
         // See https://www.drupal.org/docs/8/modules/jsonapi/pagination for
         // info on the JSON API paging logic.
+        // As of 8.x-2.x links are link objects. E.g. `$links['next']['href']`.
         if (array_key_exists('next', $links)) {
-            $next_url = $links['next'];
+            $next_url = $links['next']['href'];
             $query_string = parse_url(urldecode($next_url), PHP_URL_QUERY);
             parse_str($query_string, $query_array);
             $next_offset = $query_array['page']['offset'];
@@ -259,7 +260,7 @@ class PluginFetchResourceListFromDrupal extends AbstractFetchResourceListPlugin
             // We are on the last page, so reset the offset value to start the
             // verification cycle from the beginning.
             if (array_key_exists('first', $links)) {
-                $first_url = $links['first'];
+                $first_url = $links['first']['href'];
                 $query_string = parse_url(urldecode($first_url), PHP_URL_QUERY);
                 parse_str($query_string, $query_array);
                 $first_offset = $query_array['page']['offset'];
@@ -269,7 +270,7 @@ class PluginFetchResourceListFromDrupal extends AbstractFetchResourceListPlugin
                     $this->logger->info(
                         "PluginFetchResourceListFromDrupal has reset Drupal's JSON:API page offset to the first page.",
                         array(
-                            'Pager self URL' => $links['self']
+                            'Pager self URL' => $links['self']['href']
                         )
                     );
                 }


### PR DESCRIPTION
Issue link: #46 

## What this PR does

Updates PluginFetchResourceListFromDrupal.php for jsonapi:8.x-2.x.
- setPageOffset to use the new links structure  E.g. `$links['next']` becomes `$links['next']['href']`. 
- replaces `$node['attributes']['nid']` with `$node['attributes']['drupal_internal__nid']` [See Mateu Aguiló's blog post on the jsonapi changes](https://humanbits.es/web-development/2019/01/07/jsonapi-2/#special-properties).

(Also updates the README with a bit more information.)

## Testing Instructions

- Setup a new Islandora 8 instance. 
- Install jsonapi:8.x-2.x. _As this is the recommended version since January 2019, a simple composer require should get it._
- Load content to be checked
- Install and configure Riprap to check fixity on the Islandora 8 instance
- Check fixity. _This should throw the error: "Warning: urldecode() expects parameter 1 to be string, array given"._
- Apply the PR.
- Check fixity. _It should run as expected._

## Interested Parties
@mjordan 